### PR TITLE
ICMP, 192.0.0.8 and RFC1812

### DIFF
--- a/draft-ietf-intarea-v4-via-v6.md
+++ b/draft-ietf-intarea-v4-via-v6.md
@@ -228,10 +228,10 @@ Additionally, as per section 4.3.2.4 of [RFC1812], source address in an ICMP mes
 If the interface has no IP addresses associated with it, the router's router-id is used instead (the router-id is defined as one of the router's IP addresses).
 
 In networks implemented the proposed mechanism, it is possible for an ICMPv4 message originated by the router to be transmitted via the router's interface which doesn't have an IPv4 address assigned.
-In theory, any [RFC1812]-compliant router is required to have at least one IPv4 address (see Section 2.2.7 of [RFC1812]), and that address can be used as a source address for ICMPv4 error messages.
+In theory, any [RFC1812]-compliant router is required to have at least one IPv4 address (see Section 2.2.7 of [RFC1812]), and that address (router-id) can be used as a source address for ICMPv4 error messages.
 While routers implementing the mechanism described in this document do not need to have IPv4 addresses assigned to any interfaces, it is RECOMMENDED that to configure such a router with at least one IPv4 address, for the purpose of sending ICMPv4 error messages.
 If a router does not have any router-id (an IPv4 address) assigned, the router MUST use the mechanism described in Requirement R-22 of Section 4.8
-[RFC7600],  using the dummy address 192.0.0.8 as the source address of originated ICMPv4 packets. 
+[RFC7600],  using the dummy address 192.0.0.8 as the source address of originated ICMPv4 packets.
 However sending ICMPv4 error messages from 192.0.0.8 has the following drawbacks:
 
 * Using the same address on multiple routers may hamper debugging and fault isolation, e.g., when using the "traceroute" utility.

--- a/draft-ietf-intarea-v4-via-v6.md
+++ b/draft-ietf-intarea-v4-via-v6.md
@@ -245,7 +245,7 @@ in the case where each node may not have a unique IP address. It should be noted
 Therefore even if the router performs "v4-via-v6" routing on all interfaces, it SHOULD have at least one IPv4 address configurable, unless it is guaranteed that the router is never required to send an ICMPv4 Destination Unrechable (e.g. it is explictly prohibited by a policy, and MTU on all interfaces of that router is suffiently high to avoid fragmentation of any data packet which can reach the router).
 
 Discussion: while Section 2.2.7 of [RFC1812] says that "a router is required to have at least one IP address", that text is not using the normative language defined in Section 1.1.2 of [RFC1812].
-Therefore this document does not contradict [RFC1812] and no updated for [RFC1812] is needed.
+Therefore this document does not contradict [RFC1812] and no updates for [RFC1812] are needed.
 
 
 # Implementation Status

--- a/draft-ietf-intarea-v4-via-v6.md
+++ b/draft-ietf-intarea-v4-via-v6.md
@@ -229,7 +229,7 @@ If the interface has no IP addresses associated with it, the router's router-id 
 
 In networks implemented the proposed mechanism, it is possible for an ICMPv4 message originated by the router to be transmitted via the router's interface which doesn't have an IPv4 address assigned.
 In theory, any [RFC1812]-compliant router is required to have at least one IPv4 address (see Section 2.2.7 of [RFC1812]), and that address (router-id) can be used as a source address for ICMPv4 error messages.
-While routers implementing the mechanism described in this document do not need to have IPv4 addresses assigned to any interfaces, it is RECOMMENDED that to configure such a router with at least one IPv4 address, for the purpose of sending ICMPv4 error messages.
+While routers implementing the mechanism described in this document do not need to have IPv4 addresses assigned to any interfaces, it is RECOMMENDED to configure such a router with at least one IPv4 address, for the purpose of sending ICMPv4 error messages.
 If a router does not have any router-id (an IPv4 address) assigned, the router MUST use the mechanism described in Requirement R-22 of Section 4.8
 [RFC7600],  using the dummy address 192.0.0.8 as the source address of originated ICMPv4 packets.
 However sending ICMPv4 error messages from 192.0.0.8 has the following drawbacks:
@@ -238,7 +238,7 @@ However sending ICMPv4 error messages from 192.0.0.8 has the following drawbacks
 {{I-D.draft-ietf-intarea-extended-icmp-nodeid}} provides a possible solution to this issue, by allowing the ICMP packet to carry a "host
 identifier" that can be used to identify the router that originated the ICMP by providing a unique IP address and/or a textual name for the node,
 in the case where each node may not have a unique IP address. It should be noted that including the node identifier extension is disabled by default, and even if included, might not be recognized by receiver0.
-* Packets originating from 192.0.0.8 could be treated as bogon traffic and therefore dropped, especially when traversing network boundaries.
+* Packets originating from 192.0.0.8 could be treated as bogon traffic and dropped, especially when traversing network boundaries.
 
 Therefore even if the router performs "v4-via-v6" routing on all interfaces, it SHOULD have at least one IPv4 address configurable, unless it is guaranteed that the router is never required to send an ICMPv4 Destination Unrechable (e.g. it is explictly prohibited by a policy, and MTU on all interfaces of that router is suffiently high to avoid fragmentation of any data packet which can reach the router).
 

--- a/draft-ietf-intarea-v4-via-v6.md
+++ b/draft-ietf-intarea-v4-via-v6.md
@@ -232,6 +232,7 @@ In theory, any [RFC1812]-compliant router is required to have at least one IPv4 
 While routers implementing the mechanism described in this document do not need to have IPv4 addresses assigned to any interfaces, it is RECOMMENDED to configure such a router with at least one IPv4 address, for the purpose of sending ICMPv4 error messages.
 If a router does not have any router-id (an IPv4 address) assigned, the router MUST use the mechanism described in Requirement R-22 of Section 4.8
 [RFC7600], using the dummy address 192.0.0.8 as the source address of originated ICMPv4 packets.
+Which that behaviour is already required for Babel routers (see Section 3 of {{RFC9229}}), this document extends the requirement to all routers implementing "v4-via-v6" routing.
 
 However sending ICMPv4 error messages from 192.0.0.8 has the following drawbacks:
 

--- a/draft-ietf-intarea-v4-via-v6.md
+++ b/draft-ietf-intarea-v4-via-v6.md
@@ -231,7 +231,8 @@ In networks implemented the proposed mechanism, it is possible for an ICMPv4 mes
 In theory, any [RFC1812]-compliant router is required to have at least one IPv4 address (see Section 2.2.7 of [RFC1812]), and that address (router-id) can be used as a source address for ICMPv4 error messages.
 While routers implementing the mechanism described in this document do not need to have IPv4 addresses assigned to any interfaces, it is RECOMMENDED to configure such a router with at least one IPv4 address, for the purpose of sending ICMPv4 error messages.
 If a router does not have any router-id (an IPv4 address) assigned, the router MUST use the mechanism described in Requirement R-22 of Section 4.8
-[RFC7600],  using the dummy address 192.0.0.8 as the source address of originated ICMPv4 packets.
+[RFC7600], using the dummy address 192.0.0.8 as the source address of originated ICMPv4 packets.
+
 However sending ICMPv4 error messages from 192.0.0.8 has the following drawbacks:
 
 * Using the same address on multiple routers may hamper debugging and fault isolation, e.g., when using the "traceroute" utility.

--- a/draft-ietf-intarea-v4-via-v6.md
+++ b/draft-ietf-intarea-v4-via-v6.md
@@ -237,7 +237,7 @@ However sending ICMPv4 error messages from 192.0.0.8 has the following drawbacks
 * Using the same address on multiple routers may hamper debugging and fault isolation, e.g., when using the "traceroute" utility.
 {{I-D.draft-ietf-intarea-extended-icmp-nodeid}} provides a possible solution to this issue, by allowing the ICMP packet to carry a "host
 identifier" that can be used to identify the router that originated the ICMP by providing a unique IP address and/or a textual name for the node,
-in the case where each node may not have a unique IP address. It should be noted that including the node identifier extension is disabled by default, and even if included, might not be recognized by receiver0.
+in the case where each node may not have a unique IP address. It should be noted that including the node identifier extension is disabled by default, and even if the extension is included, it might not be recognized by receiver.
 * Packets originating from 192.0.0.8 could be treated as bogon traffic and dropped, especially when traversing network boundaries.
 
 Therefore even if the router performs "v4-via-v6" routing on all interfaces, it SHOULD have at least one IPv4 address configurable, unless it is guaranteed that the router is never required to send an ICMPv4 Destination Unrechable (e.g. it is explictly prohibited by a policy, and MTU on all interfaces of that router is suffiently high to avoid fragmentation of any data packet which can reach the router).

--- a/draft-ietf-intarea-v4-via-v6.md
+++ b/draft-ietf-intarea-v4-via-v6.md
@@ -116,8 +116,7 @@ since an IPv6 next hop can use a link-local address that is autonomously
 configured, the use of such routes enables a mode of operation where the
 network core has no statically assigned IP addresses of either family,
 which significantly reduces the amount of manual configuration required.
-(See also [RFC7404] for a discussion of the issues involved with such an
-approach.)
+([RFC7404] discusses pros and cons of such an approach.)
 
 We call a route towards an IPv4 prefix that uses an IPv6 next hop
 a "v4-via-v6" route.  V4-via-v6 routing is not restricted to routers, and


### PR DESCRIPTION
I found this text a bit confusing:

" every router that is able to forward IPv4 traffic SHOULD be able originate ICMPv4 traffic.  .....a router implementing this extension MUST be able to originate ICMPv4 packets even when the outgoing interface has not been assigned an IPv4 address."

At the very least it seems to contradict RFC1812. 
I'm rewritten that section (which looks like copy-n-paste from RFC9229, citing RFC1812.

Also adding some text why using 192.0.0.8 is not always a great idea.

Last but not least - rephrasing a reference to RFC7404